### PR TITLE
Don't include timestamp in log output & remove corrupt CPTV files

### DIFF
--- a/main.go
+++ b/main.go
@@ -105,7 +105,7 @@ func uploadFile(api *CacophonyAPI, filename string) error {
 
 	info, err := extractCPTVInfo(filename)
 	if err != nil {
-		log.Println("failed to extract CPTV info from file")
+		log.Println("failed to extract CPTV info from file. Deleting CPTV file")
 		return os.Remove(filename)
 	}
 	log.Printf("ts=%s duration=%ds", info.timestamp, info.duration)

--- a/main.go
+++ b/main.go
@@ -38,6 +38,8 @@ func main() {
 }
 
 func runMain() error {
+	log.SetFlags(0) // Removes default timestamp flag
+
 	args := procArgs()
 	conf, err := ParseConfigFile(args.ConfigFile)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -105,7 +105,8 @@ func uploadFile(api *CacophonyAPI, filename string) error {
 
 	info, err := extractCPTVInfo(filename)
 	if err != nil {
-		return err
+		log.Println("failed to extract CPTV info from file")
+		return os.Remove(filename)
 	}
 	log.Printf("ts=%s duration=%ds", info.timestamp, info.duration)
 


### PR DESCRIPTION
closes #13 
closes #12 