### PR TITLE
 Fix HTTP timeout handling 

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ recordings are typically created by the
 
 ## Releases
 
-The software uses the [GoReleaser](https://goreleaser.com) tool to
+This software uses the [GoReleaser](https://goreleaser.com) tool to
 automate releases. To produce a release:
 
 * Ensure that the `GITHUB_TOKEN` environment variable is set with a
@@ -16,6 +16,6 @@ automate releases. To produce a release:
 * Tag the release with an annotated tag. For example:
   `git tag -a "v1.4" -m "1.4 release"`
 * Push the tag to Github: `git push --tags origin`
-* Run `goreleaser`
+* Run `goreleaser --rm-dist`
 
 The configuration for GoReleaser can be found in `.goreleaser.yml`.


### PR DESCRIPTION
It turns out the http.Client time sets the maximum time an entire
request can take. 30s isn't enough for large recording to be sent over
a poor 3G link. Instead of setting the client timeout, set connection
timeouts at the http transport level.

The HTTP client is now also shared across API requests so that we can
take advantage of connection pooling. This avoids unnecessarily
setting up new connections for every request when there's lots of
recordings to upload.

Some minor tweaks to the GoReleaser instructions were also made.