### PR TITLE
Fix file globs array length

### DIFF
--- a/cmd/thermal-uploader/main.go
+++ b/cmd/thermal-uploader/main.go
@@ -42,7 +42,7 @@ const (
 
 var log = logging.NewLogger("info")
 var version = "No version provided"
-var globs = [5]string{"*.cptv", "*.avi", "*.mp4", "*.aac"}
+var globs = [4]string{"*.cptv", "*.avi", "*.mp4", "*.aac"}
 
 type Args struct {
 	ConfigDir string `arg:"-c,--config" help:"path to configuration directory"`


### PR DESCRIPTION
Because it was longer than it should have been one of the globs was an empty string, causing errors.