### PR TITLE
Restart on config changes

### DIFF
--- a/_release/thermal-uploader.service
+++ b/_release/thermal-uploader.service
@@ -1,10 +1,11 @@
 [Unit]
 Description=Cacophony Project Thermal Video uploader
 After=multi-user.target network.target
+ConditionPathExists=/etc/salt/minion_id
 
 [Service]
 ExecStart=/usr/bin/thermal-uploader
-Restart=on-failure
+Restart=always
 RestartSec=5s
 
 [Install]

--- a/cmd/thermal-uploader/config.go
+++ b/cmd/thermal-uploader/config.go
@@ -24,6 +24,7 @@ import (
 
 type Config struct {
 	Directory string `yaml:"directory"`
+	DeviceID  int    // Loaded this as part of the config so service will restart when changed.
 }
 
 func ParseConfig(configDir string) (*Config, error) {
@@ -40,6 +41,12 @@ func ParseConfig(configDir string) (*Config, error) {
 	config := &Config{
 		Directory: thermalRecorder.OutputDir,
 	}
+
+	device := goconfig.Device{}
+	if err := configRW.Unmarshal(goconfig.DeviceKey, &device); err != nil {
+		return nil, err
+	}
+	config.DeviceID = device.ID
 
 	if err := config.Validate(); err != nil {
 		return nil, err

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/TheCacophonyProject/modemd v1.11.0-tc2
 	github.com/alexflint/go-arg v1.4.2
 	github.com/godbus/dbus v4.1.0+incompatible
+	github.com/google/go-cmp v0.5.8
 	github.com/rjeczalik/notify v0.0.0-20171004161231-1aa3b9de8d84
 	github.com/spf13/afero v1.9.2
 	github.com/stretchr/testify v1.7.2


### PR DESCRIPTION
Restarting on config changes makes sure that it should upload with the correct device details. This should fix an error of test recordings not uploading after renaming the device.